### PR TITLE
Fixing FieldBytes and AffineGroupBytes serialization to also work with RMP

### DIFF
--- a/bbs_plus/Cargo.toml
+++ b/bbs_plus/Cargo.toml
@@ -28,6 +28,7 @@ zeroize.workspace = true
 blake2.workspace = true
 ark-bls12-381.workspace = true
 serde_json = "1.0"
+rmp-serde = "1.0"
 
 [features]
 default = [ "parallel" ]

--- a/bbs_plus/Cargo.toml
+++ b/bbs_plus/Cargo.toml
@@ -19,7 +19,7 @@ ark-std.workspace = true
 digest.workspace = true
 rayon = {workspace = true, optional = true}
 schnorr_pok = { version = "0.7.0", default-features = false, path = "../schnorr_pok" }
-dock_crypto_utils = { version = "0.6.0", default-features = false, path = "../utils" }
+dock_crypto_utils = { version = "0.7.0", default-features = false, path = "../utils" }
 serde.workspace = true
 serde_with.workspace = true
 zeroize.workspace = true

--- a/bbs_plus/src/lib.rs
+++ b/bbs_plus/src/lib.rs
@@ -57,6 +57,11 @@ pub mod tests {
             let ser = serde_json::to_string(&$obj).unwrap();
             let deser = serde_json::from_str::<$obj_type>(&ser).unwrap();
             assert_eq!($obj, deser);
+
+            // Test Message Pack serialization
+            let ser = rmp_serde::to_vec_named(&$obj).unwrap();
+            let deser = rmp_serde::from_slice::<$obj_type>(&ser).unwrap();
+            assert_eq!($obj, deser);
         };
     }
 }

--- a/compressed_sigma/Cargo.toml
+++ b/compressed_sigma/Cargo.toml
@@ -15,7 +15,7 @@ ark-sponge = { version = "^0.3.0", default-features = false }
 ark-poly = { version = "^0.3.0", default-features = false }
 rayon = {workspace = true, optional = true}
 digest.workspace = true
-dock_crypto_utils = { version = "0.6.0", default-features = false, path = "../utils" }
+dock_crypto_utils = { version = "0.7.0", default-features = false, path = "../utils" }
 
 [dev-dependencies]
 blake2.workspace = true

--- a/proof_system/Cargo.toml
+++ b/proof_system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proof_system"
-version = "0.14.0"
+version = "0.15.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -21,8 +21,8 @@ rayon = {workspace = true, optional = true}
 bbs_plus = { version = "0.9.0", default-features = false, path = "../bbs_plus" }
 schnorr_pok = { version = "0.7.0", default-features = false, path = "../schnorr_pok" }
 vb_accumulator = { version = "0.10.0", default-features = false, path = "../vb_accumulator" }
-dock_crypto_utils = { version = "0.6.0", default-features = false, path = "../utils" }
-saver = { version = "0.6.0", default-features = false, path = "../saver" }
+dock_crypto_utils = { version = "0.7.0", default-features = false, path = "../utils" }
+saver = { version = "0.7.0", default-features = false, path = "../saver" }
 serde.workspace = true
 serde_with.workspace = true
 ark-groth16 = { version = "^0.3.0", default-features = false }

--- a/proof_system/Cargo.toml
+++ b/proof_system/Cargo.toml
@@ -39,6 +39,7 @@ features = ["circom"]
 ark-bls12-381.workspace = true
 blake2.workspace = true
 serde_json = "1.0"
+rmp-serde = "1.0"
 test_utils = { version = "0.1.0", default-features = false, path = "../test_utils" }
 
 [features]

--- a/proof_system/src/util.rs
+++ b/proof_system/src/util.rs
@@ -216,26 +216,13 @@ macro_rules! impl_deserialize {
     };
 }
 
-use ark_ec::PairingEngine;
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::{fmt, marker::PhantomData, vec, vec::Vec};
-use legogroth16::{circom::R1CS, Proof as LegoProof, ProvingKey, VerifyingKey};
-use saver::saver_groth16::Proof;
-use serde::de::{SeqAccess, Visitor};
-use serde::{Deserializer, Serializer};
-use serde_with::{DeserializeAs, SerializeAs};
-
 use dock_crypto_utils::impl_for_groth16_struct;
 
-impl_for_groth16_struct!(LegoProvingKeyBytes, ProvingKey, "expected LegoProvingKey");
+impl_for_groth16_struct!(LegoProvingKeyBytes);
 
-impl_for_groth16_struct!(
-    LegoVerifyingKeyBytes,
-    VerifyingKey,
-    "expected LegoVerifyingKey"
-);
+impl_for_groth16_struct!(LegoVerifyingKeyBytes);
 
-impl_for_groth16_struct!(ProofBytes, Proof, "expected Proof");
-impl_for_groth16_struct!(LegoProofBytes, LegoProof, "expected LegoProofBytes");
+impl_for_groth16_struct!(ProofBytes);
+impl_for_groth16_struct!(LegoProofBytes);
 
-impl_for_groth16_struct!(R1CSBytes, R1CS, "expected R1CS");
+impl_for_groth16_struct!(R1CSBytes);

--- a/saver/Cargo.toml
+++ b/saver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saver"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -17,7 +17,7 @@ ark-relations = { version = "^0.3.0", default-features = false }
 ark-groth16 = { version = "^0.3.0", default-features = false }
 digest.workspace = true
 rayon = {workspace = true, optional = true}
-dock_crypto_utils = { version = "0.6.0", default-features = false, path = "../utils" }
+dock_crypto_utils = { version = "0.7.0", default-features = false, path = "../utils" }
 serde.workspace = true
 serde_with.workspace = true
 zeroize.workspace = true

--- a/saver/Cargo.toml
+++ b/saver/Cargo.toml
@@ -30,6 +30,7 @@ default-features = false
 blake2.workspace = true
 ark-bls12-381.workspace = true
 serde_json = "1.0"
+rmp-serde = "1.0"
 proof_system = { path = "../proof_system" }
 bbs_plus = { path = "../bbs_plus" }
 

--- a/saver/src/saver_groth16.rs
+++ b/saver/src/saver_groth16.rs
@@ -5,19 +5,14 @@ use ark_ff::PrimeField;
 use ark_relations::r1cs::{ConstraintSynthesizer, SynthesisError};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
 use ark_std::{
-    fmt,
     io::{Read, Write},
-    marker::PhantomData,
     rand::{Rng, RngCore},
-    vec,
-    vec::Vec,
     UniformRand,
 };
 
 use dock_crypto_utils::impl_for_groth16_struct;
-use serde::de::{SeqAccess, Visitor};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_with::{serde_as, DeserializeAs, SerializeAs};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 use crate::encryption::Ciphertext;
 pub use ark_groth16::{
@@ -45,16 +40,8 @@ pub struct ProvingKey<E: PairingEngine> {
     pub gamma_g1: E::G1Affine,
 }
 
-impl_for_groth16_struct!(
-    Groth16ProvingKeyBytes,
-    Groth16ProvingKey,
-    "expected Groth16ProvingKey"
-);
-impl_for_groth16_struct!(
-    Groth16VerifyingKeyBytes,
-    VerifyingKey,
-    "expected Groth16VerifyingKey"
-);
+impl_for_groth16_struct!(Groth16ProvingKeyBytes);
+impl_for_groth16_struct!(Groth16VerifyingKeyBytes);
 
 /// These parameters are needed for setting up keys for encryption/decryption
 pub fn get_gs_for_encryption<E: PairingEngine>(vk: &VerifyingKey<E>) -> &[E::G1Affine] {

--- a/saver/src/utils.rs
+++ b/saver/src/utils.rs
@@ -95,6 +95,11 @@ macro_rules! test_serialization {
         let ser = serde_json::to_string(&$obj).unwrap();
         let deser = serde_json::from_str::<$obj_type>(&ser).unwrap();
         assert_eq!($obj, deser);
+
+        // Test Message Pack serialization
+        let ser = rmp_serde::to_vec_named(&$obj).unwrap();
+        let deser = rmp_serde::from_slice::<$obj_type>(&ser).unwrap();
+        assert_eq!($obj, deser);
     };
 }
 

--- a/schnorr_pok/Cargo.toml
+++ b/schnorr_pok/Cargo.toml
@@ -18,7 +18,7 @@ ark-ec.workspace = true
 ark-std.workspace = true
 rayon = {workspace = true, optional = true}
 digest.workspace = true
-dock_crypto_utils = { version = "0.6.0", default-features = false, path = "../utils" }
+dock_crypto_utils = { version = "0.7.0", default-features = false, path = "../utils" }
 serde.workspace = true
 serde_with.workspace = true
 zeroize.workspace = true

--- a/schnorr_pok/Cargo.toml
+++ b/schnorr_pok/Cargo.toml
@@ -27,6 +27,7 @@ zeroize.workspace = true
 blake2.workspace = true
 ark-bls12-381.workspace = true
 serde_json = "1.0"
+rmp-serde = "1.0"
 
 [features]
 default = [ "parallel" ]

--- a/schnorr_pok/src/lib.rs
+++ b/schnorr_pok/src/lib.rs
@@ -344,6 +344,11 @@ mod tests {
             let obj_ser = serde_json::to_string(&$obj).unwrap();
             let obj_deser = serde_json::from_str::<$obj_type>(&obj_ser).unwrap();
             assert_eq!($obj, obj_deser);
+
+            // Test Message Pack serialization
+            let ser = rmp_serde::to_vec_named(&$obj).unwrap();
+            let deser = rmp_serde::from_slice::<$obj_type>(&ser).unwrap();
+            assert_eq!($obj, deser);
         };
     }
 

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -15,4 +15,4 @@ ark-std.workspace = true
 ark-bls12-381.workspace = true
 ark-serialize.workspace = true
 blake2.workspace = true
-proof_system = { version = "0.14.0", default-features = false, path = "../proof_system" }
+proof_system = { version = "0.15.0", default-features = false, path = "../proof_system" }

--- a/test_utils/src/serialization.rs
+++ b/test_utils/src/serialization.rs
@@ -26,6 +26,11 @@ macro_rules! test_serialization {
         let ser = serde_json::to_string(&$obj).unwrap();
         let deser = serde_json::from_str::<$obj_type>(&ser).unwrap();
         assert_eq!($obj, deser);
+
+        // Test Message Pack serialization
+        let ser = rmp_serde::to_vec_named(&$obj).unwrap();
+        let deser = rmp_serde::from_slice::<$obj_type>(&ser).unwrap();
+        assert_eq!($obj, deser);
     };
     ($obj_type:ty, $obj: ident) => {
         let mut serz = vec![];

--- a/test_utils/src/serialization.rs
+++ b/test_utils/src/serialization.rs
@@ -49,5 +49,10 @@ macro_rules! test_serialization {
         let ser = serde_json::to_string(&$obj).unwrap();
         let deser = serde_json::from_str::<$obj_type>(&ser).unwrap();
         assert_eq!($obj, deser);
+
+        // Test Message Pack serialization
+        let ser = rmp_serde::to_vec_named(&$obj).unwrap();
+        let deser = rmp_serde::from_slice::<$obj_type>(&ser).unwrap();
+        assert_eq!($obj, deser);
     };
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dock_crypto_utils"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/utils/src/serde_utils.rs
+++ b/utils/src/serde_utils.rs
@@ -1,7 +1,7 @@
 //! Serde serialization for `arkworks-rs` objects they themselves don't implement serde
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
-use ark_std::{fmt, io, marker::PhantomData, string::ToString, vec, vec::Vec};
+use ark_std::{io, string::ToString, vec::Vec};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::{DeserializeAs, SerializeAs};
 
@@ -79,7 +79,7 @@ where
 
 #[macro_export]
 macro_rules! impl_for_groth16_struct {
-    ($serializer_name: ident, $struct_name: ident, $error_msg: expr) => {
+    ($serializer_name: ident) => {
         pub type $serializer_name = ::dock_crypto_utils::serde_utils::AsCanonical;
     };
 }

--- a/vb_accumulator/Cargo.toml
+++ b/vb_accumulator/Cargo.toml
@@ -20,7 +20,7 @@ ark-std = { version = "^0.3.0", default-features = false }
 digest = "0.9"
 rayon = { version = "1", optional = true }
 schnorr_pok = { version = "0.7.0", default-features = false, path = "../schnorr_pok" }
-dock_crypto_utils = { version = "0.6.0", default-features = false, path = "../utils" }
+dock_crypto_utils = { version = "0.7.0", default-features = false, path = "../utils" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_with = { version = "1.10.0", default-features = false, features = ["macros"] }
 zeroize = { version = "1.5.5", features = ["derive"] }

--- a/vb_accumulator/Cargo.toml
+++ b/vb_accumulator/Cargo.toml
@@ -29,6 +29,7 @@ zeroize = { version = "1.5.5", features = ["derive"] }
 blake2.workspace = true
 ark-bls12-381.workspace = true
 serde_json = "1.0"
+rmp-serde = "1.0"
 
 [features]
 default = [ "parallel" ]

--- a/vb_accumulator/src/lib.rs
+++ b/vb_accumulator/src/lib.rs
@@ -75,6 +75,11 @@ pub mod tests {
             let ser = serde_json::to_string(&$obj).unwrap();
             let deser = serde_json::from_str::<$obj_type>(&ser).unwrap();
             assert_eq!($obj, deser);
+
+            // Test Message Pack serialization
+            let ser = rmp_serde::to_vec_named(&$obj).unwrap();
+            let deser = rmp_serde::from_slice::<$obj_type>(&ser).unwrap();
+            assert_eq!($obj, deser);
         };
     }
 }


### PR DESCRIPTION
Hi,

Types that contain fields serialized as `FieldBytes` or `AffineGroupBytes` did not properly serialize with serialization crates other than `serde_json`. 
The first commit here adds a few lines to the serialization tests that check serialization with `rmp_serde` (i.e., a crate where it does not work currently). The errors can be seen there.
The second commit changes the implementations of `FieldBytes` and `AffineGroupBytes` by implementing them as a generic version of the expansion of [serde_conv!](https://docs.rs/serde_with/latest/serde_with/macro.serde_conv.html). Serializing types with this new implementation now works under both `serde_json` and `rmp_serde`.

Please consider merging this in order to allow serialization with RMP (and possibly other serialization crates).