### PR TITLE
Make BBS and BBS+ parameters independent from underlying architecture

### DIFF
--- a/bbs_plus/src/setup.rs
+++ b/bbs_plus/src/setup.rs
@@ -256,7 +256,7 @@ macro_rules! impl_sig_params {
                 let mut h = cfg_into_iter!((0..=message_count))
                     .map(|i| {
                         projective_group_elem_from_try_and_incr::<E::$group_affine, D>(
-                            &concat_slices![label, b" : h_", (i as u64).to_le_bytes()],
+                            &concat_slices![label, b" : h_", (i as u32).to_le_bytes()],
                         )
                     })
                     .collect::<Vec<E::$group_projective>>();
@@ -529,7 +529,7 @@ impl<E: Pairing> SignatureParams23G1<E> {
                 projective_group_elem_from_try_and_incr::<E::G1Affine, D>(&concat_slices![
                     label,
                     b" : h_",
-                    (i as u64).to_le_bytes()
+                    (i as u32).to_le_bytes()
                 ])
             })
             .collect::<Vec<E::G1>>();

--- a/bbs_plus/src/setup.rs
+++ b/bbs_plus/src/setup.rs
@@ -256,7 +256,7 @@ macro_rules! impl_sig_params {
                 let mut h = cfg_into_iter!((0..=message_count))
                     .map(|i| {
                         projective_group_elem_from_try_and_incr::<E::$group_affine, D>(
-                            &concat_slices![label, b" : h_", i.to_le_bytes()],
+                            &concat_slices![label, b" : h_", (i as u64).to_le_bytes()],
                         )
                     })
                     .collect::<Vec<E::$group_projective>>();
@@ -529,7 +529,7 @@ impl<E: Pairing> SignatureParams23G1<E> {
                 projective_group_elem_from_try_and_incr::<E::G1Affine, D>(&concat_slices![
                     label,
                     b" : h_",
-                    i.to_le_bytes()
+                    (i as u64).to_le_bytes()
                 ])
             })
             .collect::<Vec<E::G1>>();


### PR DESCRIPTION
Thank you for publishing such an impressive library!

I've observed that when generating BBS(+) parameters `h_i`, even with the same `label` and `message_count`, the resultant `h_i` values can differ based on the execution environment: 32-bit (e.g., wasm32) versus 64-bit. This discrepancy seems to stem from the `usize` type of the parameter `i`, which varies depending on the environment. To illustrate, in a 32-bit setting, `h_1` might be generated as `H("label : h_0001 0000 0000 0000")`, while in a 64-bit context, it could be `H("label : h_0001 0000 0000 0000 0000 0000 0000 0000")`. This leads to distinct `h_1` values for identical `label` and `message_count`.

In this PR, I suggest a straightforward remedy: casting `i` to `u64` just before calculating `h_i`. I would greatly appreciate your review on this as this could introduce a breaking change for 32-bit environments.