### PR TITLE
Coconut Proof allows empty blinding messages

### DIFF
--- a/benches/benches/ps_proof.rs
+++ b/benches/benches/ps_proof.rs
@@ -76,7 +76,7 @@ fn pok_sig_benchmark(c: &mut Criterion) {
         let sig = &sigs_range[i];
 
         let mut prove_group = c.benchmark_group(format!("Creating proof for Proof-of-knowledge of signature and corresponding multi-message of size {}", count));
-        for (_j, r_count) in k.iter().enumerate() {
+        for (j, r_count) in k.iter().enumerate() {
             prove_group.bench_with_input(
                 BenchmarkId::from_parameter(format!("Revealing {} messages", r_count)),
                 &r_count,
@@ -89,7 +89,7 @@ fn pok_sig_benchmark(c: &mut Criterion) {
                                     .iter()
                                     .enumerate()
                                     .merge_join_by(
-                                        revealed_indices[i].iter(),
+                                        revealed_indices[j].iter(),
                                         |(m_idx, _), reveal_idx| m_idx.cmp(reveal_idx),
                                     )
                                     .map(|either| match either {

--- a/coconut/src/proof/messages_pok/mod.rs
+++ b/coconut/src/proof/messages_pok/mod.rs
@@ -230,16 +230,16 @@ mod tests {
 
             let pok = MessagesPoKGenerator::init(&mut rng, &messages, &params, &h).unwrap();
 
-            let mut chal_bytes_prover = vec![];
-            pok.challenge_contribution(&mut chal_bytes_prover, &params, &h)
+            let mut chal_bytes = vec![];
+            pok.challenge_contribution(&mut chal_bytes, &params, &h)
                 .unwrap();
-            let challenge_prover =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes_prover);
+            let challenge =
+                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
-            let proof = pok.clone().gen_proof(&challenge_prover).unwrap();
+            let proof = pok.clone().gen_proof(&challenge).unwrap();
 
             proof
-                .verify(&challenge_prover, empty(), &params, &h)
+                .verify(&challenge, empty(), &params, &h)
                 .unwrap();
         }
     }
@@ -269,21 +269,16 @@ mod tests {
 
             assert_eq!(messages.len() / 2, pok.com_j.len());
 
-            let mut chal_bytes_prover = vec![];
-            pok.challenge_contribution(&mut chal_bytes_prover, &params, &h)
+            let mut chal_bytes = vec![];
+            pok.challenge_contribution(&mut chal_bytes, &params, &h)
                 .unwrap();
-            let challenge_prover =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes_prover);
+            let challenge =
+                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
-            let proof = pok.clone().gen_proof(&challenge_prover).unwrap();
+            let proof = pok.clone().gen_proof(&challenge).unwrap();
 
             proof
-                .verify(
-                    &challenge_prover,
-                    (0..messages.len()).step_by(2),
-                    &params,
-                    &h,
-                )
+                .verify(&challenge, (0..messages.len()).step_by(2), &params, &h)
                 .unwrap();
         }
     }
@@ -385,17 +380,17 @@ mod tests {
 
             assert_eq!(messages.len() / 2, pok.com_j.len());
 
-            let mut chal_bytes_prover = vec![];
-            pok.challenge_contribution(&mut chal_bytes_prover, &params, &h)
+            let mut chal_bytes = vec![];
+            pok.challenge_contribution(&mut chal_bytes, &params, &h)
                 .unwrap();
-            let challenge_prover =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes_prover);
+            let challenge =
+                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
-            let proof = pok.clone().gen_proof(&challenge_prover).unwrap();
+            let proof = pok.clone().gen_proof(&challenge).unwrap();
             let mut indices = (0..messages.len()).step_by(2).rev();
 
             assert_eq!(
-                proof.verify(&challenge_prover, indices.clone(), &params, &h,),
+                proof.verify(&challenge, indices.clone(), &params, &h,),
                 Err(MessagesPoKError::RevealedIndicesMustBeUniqueAndSorted {
                     previous: indices.next().unwrap(),
                     current: indices.next().unwrap()
@@ -426,16 +421,16 @@ mod tests {
             )
             .unwrap();
 
-            let mut chal_bytes_prover = vec![];
-            pok.challenge_contribution(&mut chal_bytes_prover, &params, &h)
+            let mut chal_bytes = vec![];
+            pok.challenge_contribution(&mut chal_bytes, &params, &h)
                 .unwrap();
-            let challenge_prover =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes_prover);
+            let challenge =
+                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
-            let proof = pok.clone().gen_proof(&challenge_prover).unwrap();
+            let proof = pok.clone().gen_proof(&challenge).unwrap();
 
             proof
-                .verify(&challenge_prover, empty(), &params, &h)
+                .verify(&challenge, empty(), &params, &h)
                 .unwrap();
         }
     }
@@ -460,22 +455,18 @@ mod tests {
         )
         .unwrap();
 
-        let mut chal_bytes_prover = vec![];
-        pok.challenge_contribution(&mut chal_bytes_prover, &params, &h)
+        let mut chal_bytes = vec![];
+        pok.challenge_contribution(&mut chal_bytes, &params, &h)
             .unwrap();
-        let challenge_prover =
-            compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes_prover);
+        let challenge =
+            compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
-        let mut proof = pok.clone().gen_proof(&challenge_prover).unwrap();
-        assert!(proof
-            .verify(&challenge_prover, empty(), &params, &h)
-            .is_ok());
+        let mut proof = pok.clone().gen_proof(&challenge).unwrap();
+        assert!(proof.verify(&challenge, empty(), &params, &h).is_ok());
 
         proof.com_resp.response.0[0] = rand(&mut rng);
 
-        assert!(proof
-            .verify(&challenge_prover, empty(), &params, &h)
-            .is_err());
+        assert!(proof.verify(&challenge, empty(), &params, &h).is_err());
     }
 
     #[test]
@@ -498,22 +489,18 @@ mod tests {
         )
         .unwrap();
 
-        let mut chal_bytes_prover = vec![];
-        pok.challenge_contribution(&mut chal_bytes_prover, &params, &h)
+        let mut chal_bytes = vec![];
+        pok.challenge_contribution(&mut chal_bytes, &params, &h)
             .unwrap();
-        let challenge_prover =
-            compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes_prover);
+        let challenge =
+            compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
-        let mut proof = pok.clone().gen_proof(&challenge_prover).unwrap();
-        assert!(proof
-            .verify(&challenge_prover, empty(), &params, &h)
-            .is_ok());
+        let mut proof = pok.clone().gen_proof(&challenge).unwrap();
+        assert!(proof.verify(&challenge, empty(), &params, &h).is_ok());
 
         *proof.com_resp.value = G1::rand(&mut rng).into_affine();
 
-        assert!(proof
-            .verify(&challenge_prover, empty(), &params, &h)
-            .is_err());
+        assert!(proof.verify(&challenge, empty(), &params, &h).is_err());
     }
 
     #[test]
@@ -536,23 +523,19 @@ mod tests {
         )
         .unwrap();
 
-        let mut chal_bytes_prover = vec![];
-        pok.challenge_contribution(&mut chal_bytes_prover, &params, &h)
+        let mut chal_bytes = vec![];
+        pok.challenge_contribution(&mut chal_bytes, &params, &h)
             .unwrap();
-        let challenge_prover =
-            compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes_prover);
+        let challenge =
+            compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
-        let mut proof = pok.clone().gen_proof(&challenge_prover).unwrap();
+        let mut proof = pok.clone().gen_proof(&challenge).unwrap();
 
-        assert!(proof
-            .verify(&challenge_prover, empty(), &params, &h)
-            .is_ok());
+        assert!(proof.verify(&challenge, empty(), &params, &h).is_ok());
 
         *proof.com_j_resp.first_mut().unwrap().value = G1::rand(&mut rng).into_affine();
 
-        assert!(proof
-            .verify(&challenge_prover, empty(), &params, &h)
-            .is_err());
+        assert!(proof.verify(&challenge, empty(), &params, &h).is_err());
     }
 
     #[test]
@@ -561,20 +544,23 @@ mod tests {
         let (_, _, params, messages) = test_setup::<Bls12_381, Blake2b512, _>(&mut rng, 1);
         let h = G1::rand(&mut rng).into_affine();
 
-        let pok = MessagesPoKGenerator::init(&mut rng, &[], &params, &h)
-            .unwrap();
+        let pok = MessagesPoKGenerator::init(
+            &mut rng,
+            messages.iter().map(|_| CommitMessage::RevealMessage),
+            &params,
+            &h,
+        )
+        .unwrap();
 
         let mut chal_bytes = vec![];
         pok.challenge_contribution(&mut chal_bytes, &params, &h)
             .unwrap();
-        let challenge_prover =
+        let challenge =
             compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
-        let proof = pok.clone().gen_proof(&challenge_prover).unwrap();
+        let proof = pok.clone().gen_proof(&challenge).unwrap();
         let indices = (0..messages.len()).rev();
 
-        assert!(proof
-            .verify(&challenge_prover, indices.clone(), &params, &h)
-            .is_ok());
+        assert!(proof.verify(&challenge, indices.clone(), &params, &h).is_ok());
     }
 }

--- a/coconut/src/proof/messages_pok/mod.rs
+++ b/coconut/src/proof/messages_pok/mod.rs
@@ -564,11 +564,11 @@ mod tests {
         let pok = MessagesPoKGenerator::init(&mut rng, &[], &params, &h)
             .unwrap();
 
-        let mut chal_bytes_prover = vec![];
-        pok.challenge_contribution(&mut chal_bytes_prover, &params, &h)
+        let mut chal_bytes = vec![];
+        pok.challenge_contribution(&mut chal_bytes, &params, &h)
             .unwrap();
         let challenge_prover =
-            compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes_prover);
+            compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
         let proof = pok.clone().gen_proof(&challenge_prover).unwrap();
         let indices = (0..messages.len()).rev();

--- a/coconut/src/proof/messages_pok/mod.rs
+++ b/coconut/src/proof/messages_pok/mod.rs
@@ -233,14 +233,11 @@ mod tests {
             let mut chal_bytes = vec![];
             pok.challenge_contribution(&mut chal_bytes, &params, &h)
                 .unwrap();
-            let challenge =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
+            let challenge = compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
             let proof = pok.clone().gen_proof(&challenge).unwrap();
 
-            proof
-                .verify(&challenge, empty(), &params, &h)
-                .unwrap();
+            proof.verify(&challenge, empty(), &params, &h).unwrap();
         }
     }
 
@@ -272,8 +269,7 @@ mod tests {
             let mut chal_bytes = vec![];
             pok.challenge_contribution(&mut chal_bytes, &params, &h)
                 .unwrap();
-            let challenge =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
+            let challenge = compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
             let proof = pok.clone().gen_proof(&challenge).unwrap();
 
@@ -383,8 +379,7 @@ mod tests {
             let mut chal_bytes = vec![];
             pok.challenge_contribution(&mut chal_bytes, &params, &h)
                 .unwrap();
-            let challenge =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
+            let challenge = compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
             let proof = pok.clone().gen_proof(&challenge).unwrap();
             let mut indices = (0..messages.len()).step_by(2).rev();
@@ -424,14 +419,11 @@ mod tests {
             let mut chal_bytes = vec![];
             pok.challenge_contribution(&mut chal_bytes, &params, &h)
                 .unwrap();
-            let challenge =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
+            let challenge = compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
             let proof = pok.clone().gen_proof(&challenge).unwrap();
 
-            proof
-                .verify(&challenge, empty(), &params, &h)
-                .unwrap();
+            proof.verify(&challenge, empty(), &params, &h).unwrap();
         }
     }
 
@@ -458,8 +450,7 @@ mod tests {
         let mut chal_bytes = vec![];
         pok.challenge_contribution(&mut chal_bytes, &params, &h)
             .unwrap();
-        let challenge =
-            compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
+        let challenge = compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
         let mut proof = pok.clone().gen_proof(&challenge).unwrap();
         assert!(proof.verify(&challenge, empty(), &params, &h).is_ok());
@@ -492,8 +483,7 @@ mod tests {
         let mut chal_bytes = vec![];
         pok.challenge_contribution(&mut chal_bytes, &params, &h)
             .unwrap();
-        let challenge =
-            compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
+        let challenge = compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
         let mut proof = pok.clone().gen_proof(&challenge).unwrap();
         assert!(proof.verify(&challenge, empty(), &params, &h).is_ok());
@@ -526,8 +516,7 @@ mod tests {
         let mut chal_bytes = vec![];
         pok.challenge_contribution(&mut chal_bytes, &params, &h)
             .unwrap();
-        let challenge =
-            compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
+        let challenge = compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
         let mut proof = pok.clone().gen_proof(&challenge).unwrap();
 
@@ -555,12 +544,13 @@ mod tests {
         let mut chal_bytes = vec![];
         pok.challenge_contribution(&mut chal_bytes, &params, &h)
             .unwrap();
-        let challenge =
-            compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
+        let challenge = compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
         let proof = pok.clone().gen_proof(&challenge).unwrap();
         let indices = (0..messages.len()).rev();
 
-        assert!(proof.verify(&challenge, indices.clone(), &params, &h).is_ok());
+        assert!(proof
+            .verify(&challenge, indices.clone(), &params, &h)
+            .is_ok());
     }
 }

--- a/coconut/src/proof/mod.rs
+++ b/coconut/src/proof/mod.rs
@@ -177,9 +177,7 @@ impl<'pair, Pair, F: PrimeField> UnpackedBlindedMessages<'pair, Pair, F> {
 
         let (paired, (msgs, blindings)): (Vec<_>, _) =
             process_results(paired, |iter| iter.unzip())?;
-        if paired.is_empty() {
-            Ok(Self(paired, msgs, blindings))
-        } else if pair_with.len() != total_count {
+        if pair_with.len() != total_count {
             Err(MessageUnpackingError::LessMessagesThanExpected {
                 provided: total_count,
                 expected: pair_with.len(),

--- a/coconut/src/proof/mod.rs
+++ b/coconut/src/proof/mod.rs
@@ -178,7 +178,7 @@ impl<'pair, Pair, F: PrimeField> UnpackedBlindedMessages<'pair, Pair, F> {
         let (paired, (msgs, blindings)): (Vec<_>, _) =
             process_results(paired, |iter| iter.unzip())?;
         if paired.is_empty() {
-            Err(MessageUnpackingError::NoMessagesProvided)
+            Ok(Self(paired, msgs, blindings))
         } else if pair_with.len() != total_count {
             Err(MessageUnpackingError::LessMessagesThanExpected {
                 provided: total_count,

--- a/coconut/src/proof/signature_pok/mod.rs
+++ b/coconut/src/proof/signature_pok/mod.rs
@@ -176,14 +176,11 @@ mod tests {
             let mut chal_bytes = vec![];
             pok.challenge_contribution(&mut chal_bytes, &pk, &params)
                 .unwrap();
-            let challenge =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
+            let challenge = compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
             let proof = pok.clone().gen_proof(&challenge).unwrap();
 
-            proof
-                .verify(&challenge, empty(), &pk, &params)
-                .unwrap();
+            proof.verify(&challenge, empty(), &pk, &params).unwrap();
         })
     }
 
@@ -215,14 +212,11 @@ mod tests {
             let mut chal_bytes = vec![];
             pok.challenge_contribution(&mut chal_bytes, &pk, &params)
                 .unwrap();
-            let challenge =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
+            let challenge = compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
             let proof = pok.clone().gen_proof(&challenge).unwrap();
 
-            proof
-                .verify(&challenge, reveal_msgs, &pk, &params)
-                .unwrap();
+            proof.verify(&challenge, reveal_msgs, &pk, &params).unwrap();
         })
     }
 
@@ -324,8 +318,7 @@ mod tests {
             let mut chal_bytes = vec![];
             pok.challenge_contribution(&mut chal_bytes, &pk, &params)
                 .unwrap();
-            let challenge =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
+            let challenge = compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
             let proof = pok.clone().gen_proof(&challenge).unwrap();
             let mut revealed = reveal_msgs.into_iter().rev();
@@ -359,8 +352,7 @@ mod tests {
         let mut chal_bytes = vec![];
         pok.challenge_contribution(&mut chal_bytes, &pk, &params)
             .unwrap();
-        let challenge =
-            compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
+        let challenge = compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
         let proof = pok.clone().gen_proof(&challenge).unwrap();
         let revealed = messages.iter().enumerate().into_iter().rev();
@@ -386,21 +378,14 @@ mod tests {
             let mut chal_bytes = vec![];
             pok.challenge_contribution(&mut chal_bytes, &pk, &params)
                 .unwrap();
-            let challenge =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
+            let challenge = compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
             let mut proof = pok.clone().gen_proof(&challenge).unwrap();
 
-            assert!(proof
-                .verify(&challenge, empty(), &pk, &params)
-                .is_ok());
-            assert!(proof
-                .verify(&challenge, empty(), &pk1, &params)
-                .is_err());
+            assert!(proof.verify(&challenge, empty(), &pk, &params).is_ok());
+            assert!(proof.verify(&challenge, empty(), &pk1, &params).is_err());
             *proof.k.value = G2Projective::rand(&mut rng).into_affine();
-            assert!(proof
-                .verify(&challenge, empty(), &pk, &params)
-                .is_err())
+            assert!(proof.verify(&challenge, empty(), &pk, &params).is_err())
         })
     }
 
@@ -431,8 +416,7 @@ mod tests {
             let mut chal_bytes = vec![];
             pok.challenge_contribution(&mut chal_bytes, &pk, &params)
                 .unwrap();
-            let challenge =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
+            let challenge = compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
             let proof = pok.clone().gen_proof(&challenge).unwrap();
 

--- a/coconut/src/proof/signature_pok/mod.rs
+++ b/coconut/src/proof/signature_pok/mod.rs
@@ -173,16 +173,16 @@ mod tests {
 
             let pok = SignaturePoKGenerator::init(&mut rng, &messages, &sig, &pk, &params).unwrap();
 
-            let mut chal_bytes_prover = vec![];
-            pok.challenge_contribution(&mut chal_bytes_prover, &pk, &params)
+            let mut chal_bytes = vec![];
+            pok.challenge_contribution(&mut chal_bytes, &pk, &params)
                 .unwrap();
-            let challenge_prover =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes_prover);
+            let challenge =
+                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
-            let proof = pok.clone().gen_proof(&challenge_prover).unwrap();
+            let proof = pok.clone().gen_proof(&challenge).unwrap();
 
             proof
-                .verify(&challenge_prover, empty(), &pk, &params)
+                .verify(&challenge, empty(), &pk, &params)
                 .unwrap();
         })
     }
@@ -212,16 +212,16 @@ mod tests {
             )
             .unwrap();
 
-            let mut chal_bytes_prover = vec![];
-            pok.challenge_contribution(&mut chal_bytes_prover, &pk, &params)
+            let mut chal_bytes = vec![];
+            pok.challenge_contribution(&mut chal_bytes, &pk, &params)
                 .unwrap();
-            let challenge_prover =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes_prover);
+            let challenge =
+                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
-            let proof = pok.clone().gen_proof(&challenge_prover).unwrap();
+            let proof = pok.clone().gen_proof(&challenge).unwrap();
 
             proof
-                .verify(&challenge_prover, reveal_msgs, &pk, &params)
+                .verify(&challenge, reveal_msgs, &pk, &params)
                 .unwrap();
         })
     }
@@ -321,17 +321,17 @@ mod tests {
             )
             .unwrap();
 
-            let mut chal_bytes_prover = vec![];
-            pok.challenge_contribution(&mut chal_bytes_prover, &pk, &params)
+            let mut chal_bytes = vec![];
+            pok.challenge_contribution(&mut chal_bytes, &pk, &params)
                 .unwrap();
-            let challenge_prover =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes_prover);
+            let challenge =
+                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
-            let proof = pok.clone().gen_proof(&challenge_prover).unwrap();
+            let proof = pok.clone().gen_proof(&challenge).unwrap();
             let mut revealed = reveal_msgs.into_iter().rev();
 
             assert_eq!(
-                proof.verify(&challenge_prover, revealed.clone(), &pk, &params,),
+                proof.verify(&challenge, revealed.clone(), &pk, &params,),
                 Err(SignaturePoKError::RevealedIndicesMustBeUniqueAndSorted {
                     previous: revealed.next().unwrap().0,
                     current: revealed.next().unwrap().0
@@ -347,19 +347,26 @@ mod tests {
 
         let sig = Signature::new(&mut rng, messages.as_slice(), &sk, &params).unwrap();
 
-        let pok = SignaturePoKGenerator::init(&mut rng, &[], &sig, &pk, &params).unwrap();
+        let pok = SignaturePoKGenerator::init(
+            &mut rng,
+            messages.iter().map(|_| CommitMessage::RevealMessage),
+            &sig,
+            &pk,
+            &params,
+        )
+        .unwrap();
 
         let mut chal_bytes = vec![];
         pok.challenge_contribution(&mut chal_bytes, &pk, &params)
             .unwrap();
-        let challenge_prover =
+        let challenge =
             compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
-        let proof = pok.clone().gen_proof(&challenge_prover).unwrap();
+        let proof = pok.clone().gen_proof(&challenge).unwrap();
         let revealed = messages.iter().enumerate().into_iter().rev();
 
         assert!(proof
-            .verify(&challenge_prover, revealed.clone(), &pk, &params)
+            .verify(&challenge, revealed.clone(), &pk, &params)
             .is_ok());
     }
 
@@ -376,23 +383,23 @@ mod tests {
 
             let pok = SignaturePoKGenerator::init(&mut rng, &messages, &sig, &pk, &params).unwrap();
 
-            let mut chal_bytes_prover = vec![];
-            pok.challenge_contribution(&mut chal_bytes_prover, &pk, &params)
+            let mut chal_bytes = vec![];
+            pok.challenge_contribution(&mut chal_bytes, &pk, &params)
                 .unwrap();
-            let challenge_prover =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes_prover);
+            let challenge =
+                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
-            let mut proof = pok.clone().gen_proof(&challenge_prover).unwrap();
+            let mut proof = pok.clone().gen_proof(&challenge).unwrap();
 
             assert!(proof
-                .verify(&challenge_prover, empty(), &pk, &params)
+                .verify(&challenge, empty(), &pk, &params)
                 .is_ok());
             assert!(proof
-                .verify(&challenge_prover, empty(), &pk1, &params)
+                .verify(&challenge, empty(), &pk1, &params)
                 .is_err());
             *proof.k.value = G2Projective::rand(&mut rng).into_affine();
             assert!(proof
-                .verify(&challenge_prover, empty(), &pk, &params)
+                .verify(&challenge, empty(), &pk, &params)
                 .is_err())
         })
     }
@@ -421,13 +428,13 @@ mod tests {
 
             let pok = SignaturePoKGenerator::init(&mut rng, comms, &sig, &pk, &params).unwrap();
 
-            let mut chal_bytes_prover = vec![];
-            pok.challenge_contribution(&mut chal_bytes_prover, &pk, &params)
+            let mut chal_bytes = vec![];
+            pok.challenge_contribution(&mut chal_bytes, &pk, &params)
                 .unwrap();
-            let challenge_prover =
-                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes_prover);
+            let challenge =
+                compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
-            let proof = pok.clone().gen_proof(&challenge_prover).unwrap();
+            let proof = pok.clone().gen_proof(&challenge).unwrap();
 
             for idx in committed_msg_indices {
                 assert_eq!(

--- a/coconut/src/proof/signature_pok/mod.rs
+++ b/coconut/src/proof/signature_pok/mod.rs
@@ -347,12 +347,20 @@ mod tests {
 
         let sig = Signature::new(&mut rng, messages.as_slice(), &sk, &params).unwrap();
 
-        assert_eq!(
-            SignaturePoKGenerator::init(&mut rng, &[], &sig, &pk, &params),
-            Err(SignaturePoKError::MessageInputError(
-                MessageUnpackingError::NoMessagesProvided
-            ))
-        );
+        let pok = SignaturePoKGenerator::init(&mut rng, &[], &sig, &pk, &params).unwrap();
+
+        let mut chal_bytes_prover = vec![];
+        pok.challenge_contribution(&mut chal_bytes_prover, &pk, &params)
+            .unwrap();
+        let challenge_prover =
+            compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes_prover);
+
+        let proof = pok.clone().gen_proof(&challenge_prover).unwrap();
+        let revealed = messages.iter().enumerate().into_iter().rev();
+
+        assert!(proof
+            .verify(&challenge_prover, revealed.clone(), &pk, &params)
+            .is_ok());
     }
 
     #[test]

--- a/coconut/src/proof/signature_pok/mod.rs
+++ b/coconut/src/proof/signature_pok/mod.rs
@@ -349,11 +349,11 @@ mod tests {
 
         let pok = SignaturePoKGenerator::init(&mut rng, &[], &sig, &pk, &params).unwrap();
 
-        let mut chal_bytes_prover = vec![];
-        pok.challenge_contribution(&mut chal_bytes_prover, &pk, &params)
+        let mut chal_bytes = vec![];
+        pok.challenge_contribution(&mut chal_bytes, &pk, &params)
             .unwrap();
         let challenge_prover =
-            compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes_prover);
+            compute_random_oracle_challenge::<Fr, Blake2b512>(&chal_bytes);
 
         let proof = pok.clone().gen_proof(&challenge_prover).unwrap();
         let revealed = messages.iter().enumerate().into_iter().rev();


### PR DESCRIPTION
## Issue

https://github.com/docknetwork/crypto/issues/20

## What I do

- change UnpackedBlindedMessages impl to return empty proof even if blinding message is empty
- change ps_proof's proving to use the index not i but j